### PR TITLE
Introduce ptrhold flag to allow overriding the automatic PTR creation

### DIFF
--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -19,7 +19,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
       if line[0] == ';' && line.length > 18
         currentzone = line[%r{(?:.*?')(.*?)\/}, 1]
         if currentzone.respond_to?(:to_str); currentzone = currentzone.downcase end
-        # Puppet.debug("current zone updated: #{currentzone}")
+        Puppet.debug("current zone updated: #{currentzone}")
       elsif line[0] != ';'
         line = line.strip.split(' ', 5)
         rr = {}
@@ -85,9 +85,9 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     system(cmd)
 
     # FIXME: This will generate PTR records, but assumes the arpa zones are preexisting.
-    if (should[:type] == 'A') && !(@heldptr.key? should[:record])
+    if (should[:type] == 'A') && !(@heldptr.key? should[:data])
       if should[:holdptr] == 'true'
-        @heldptr[should[:record]] = should[:holdptr]
+        @heldptr[should[:data]] = should[:holdptr]
       end
       fqdn = should[:record]
       if fqdn[fqdn.length - 1] != '.'
@@ -131,9 +131,9 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
             ' | nsupdate -4 -l"
           end
     system(cmd)
-    if (should[:type] == 'A') && !(@heldptr.key? should[:record])
+    if (should[:type] == 'A') && !(@heldptr.key? should[:data])
       if should[:holdptr] == 'true'
-        @heldptr[should[:record]] = should[:holdptr]
+        @heldptr[should[:data]] = should[:holdptr]
       end
       fqdn = should[:record]
       if fqdn[fqdn.length - 1] != '.'

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -8,7 +8,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     super()
     system('rndc', 'dumpdb', '-zones')
     # Have to wait to ensure file is actually populated...embarrassingly this was the source of much wheel spinning.
-    sleep(2)
+    #sleep(2)
     Puppet.debug('Parsing dump for existing resource records...')
     @records = []
     @heldptr = {}

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -7,6 +7,8 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
   def initialize
     super()
     system('rndc', 'dumpdb', '-zones')
+    # Have to wait to ensure file is actually populated...embarrassingly this was the source of much wheel spinning.
+    sleep(2)
     Puppet.debug('Parsing dump for existing resource records...')
     @records = []
     @heldptr = {}

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -87,7 +87,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     system(cmd)
 
     # FIXME: This will generate PTR records, but assumes the arpa zones are preexisting.
-    if (should[:type] == 'A') 
+    if should[:type] == 'A'
       unless @heldptr.key? should[:data].to_sym
         if should[:holdptr]
           context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")
@@ -136,7 +136,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
             ' | nsupdate -4 -l"
           end
     system(cmd)
-    if (should[:type] == 'A') 
+    if should[:type] == 'A'
       unless (@heldptr.key? should[:data].to_sym)
         if should[:holdptr]
           context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -89,6 +89,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     # FIXME: This will generate PTR records, but assumes the arpa zones are preexisting.
     if (should[:type] == 'A') && !(@heldptr.key? should[:data])
       if should[:holdptr] == 'true'
+        context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")
         @heldptr[should[:data]] = should[:holdptr]
       end
       fqdn = should[:record]
@@ -135,6 +136,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     system(cmd)
     if (should[:type] == 'A') && !(@heldptr.key? should[:data])
       if should[:holdptr] == 'true'
+        context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")
         @heldptr[should[:data]] = should[:holdptr]
       end
       fqdn = should[:record]

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -8,10 +8,11 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     super()
     system('rndc', 'dumpdb', '-zones')
     # Have to wait to ensure file is actually populated...embarrassingly this was the source of much wheel spinning.
-    sleep(2)
+    sleep(0)
     Puppet.debug('Parsing dump for existing resource records...')
     @records = []
     @heldptr = {}
+    @canonicalized = false
     currentzone = ''
     # FIXME: location varies based on config/OS
     unless File.exist?('/var/cache/bind/named_dump.db')
@@ -183,8 +184,9 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
 
   def canonicalize(context, resources)
     Puppet.debug("canonicalize called, context: #{context}")
+    return resources if @canonicalized
     resources.each do |r|
-      context.debug(r.inspect)
+      # context.debug(r.inspect)
       if r[:record].respond_to?(:to_str)
         r[:record] = r[:record].downcase.strip
       end
@@ -198,5 +200,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
         r[:data] = r[:data].tr('\"', '')
       end
     end
+    @canonicalized = true
+    return resources
   end
 end

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -89,9 +89,9 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     # FIXME: This will generate PTR records, but assumes the arpa zones are preexisting.
     if should[:type] == 'A'
       unless @heldptr.key? should[:data].to_sym
-        if should[:holdptr]
+        if should[:ptrhold]
           context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")
-          @heldptr[should[:data].to_sym] = should[:holdptr]
+          @heldptr[should[:data].to_sym] = should[:record]
         end
         fqdn = should[:record]
         if fqdn[fqdn.length - 1] != '.'
@@ -137,8 +137,8 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
           end
     system(cmd)
     if should[:type] == 'A'
-      unless (@heldptr.key? should[:data].to_sym)
-        if should[:holdptr]
+      unless @heldptr.key? should[:data].to_sym
+        if should[:ptrhold]
           context.debug("Adding sticky PTR entry for #{should[:data]}->#{should[:record]}")
           @heldptr[should[:data].to_sym] = should[:record]
         end

--- a/lib/puppet/provider/resource_record/resource_record.rb
+++ b/lib/puppet/provider/resource_record/resource_record.rb
@@ -8,7 +8,7 @@ class Puppet::Provider::ResourceRecord::ResourceRecord < Puppet::ResourceApi::Si
     super()
     system('rndc', 'dumpdb', '-zones')
     # Have to wait to ensure file is actually populated...embarrassingly this was the source of much wheel spinning.
-    #sleep(2)
+    sleep(2)
     Puppet.debug('Parsing dump for existing resource records...')
     @records = []
     @heldptr = {}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,27 +7,6 @@
 class bind::install {
   assert_private()
 
-  if $bind::authoritative {
-    ensure_packages(
-      [
-        'g++',
-        'make',
-      ],
-      {
-        ensure => installed,
-        before => Package['dnsruby'],
-      },
-    )
-
-    ensure_packages(
-      'dnsruby',
-      {
-        ensure   => installed,
-        provider => puppet_gem,
-      },
-    )
-  }
-
   if $bind::package_backport {
     require apt::backports
   }

--- a/spec/classes/bind_spec.rb
+++ b/spec/classes/bind_spec.rb
@@ -217,28 +217,6 @@ describe 'bind' do
         end
 
         it { is_expected.to compile.with_all_deps }
-
-        # dnsruby build dependencies
-        if os_facts[:os]['name'] == 'Debian'
-          [
-            'g++',
-            'make',
-          ].each do |pkg|
-            it do
-              is_expected.to contain_package(pkg).with(
-                ensure: 'installed',
-                before: 'Package[dnsruby]',
-              )
-            end
-          end
-        end
-
-        it do
-          is_expected.to contain_package('dnsruby').with(
-            ensure: 'installed',
-            provider: 'puppet_gem',
-          )
-        end
       end
 
       context 'with dev packages' do


### PR DESCRIPTION
`ptrhold` is a boolean flag on resource records preventing automatic creation of additional PTR records for any given A record that would overwrite your desired value. 